### PR TITLE
Improve camera handling and OCR cleanup

### DIFF
--- a/app/src/main/java/com/sirimocr/app/ocr/MLKitOcrProcessor.kt
+++ b/app/src/main/java/com/sirimocr/app/ocr/MLKitOcrProcessor.kt
@@ -7,12 +7,13 @@ import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.sirimocr.app.data.model.SirimData
 import com.sirimocr.app.data.model.SirimOcrResult
+import java.io.Closeable
 import kotlinx.coroutines.tasks.await
 
 class MLKitOcrProcessor(
     private val validationEngine: ValidationEngine = ValidationEngine(),
     private val fieldExtractor: SirimFieldExtractor = SirimFieldExtractor()
-) {
+) : Closeable {
 
     private val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
@@ -59,5 +60,8 @@ class MLKitOcrProcessor(
         }
         val recognitionScore = if (count == 0) 0f else total / count
         return (recognitionScore * 0.7f + validationScore * 0.3f).coerceIn(0f, 1f)
+    }
+    override fun close() {
+        textRecognizer.close()
     }
 }


### PR DESCRIPTION
## Summary
- implement Closeable cleanup for MLKitOcrProcessor so ML Kit resources are released when the fragment is torn down
- remove the duplicate capture click listener and close the OCR processor when the dashboard view is destroyed
- add structured camera error handling, logging, and restart logic to make the capture flow more resilient

## Testing
- `./gradlew lint` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68d39cc3774883259ef0d3836f45db83