### PR TITLE
Fix manifest duplication and tidy Gradle config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
-    id("kotlin-kapt")
+    id("org.jetbrains.kotlin.kapt")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
 }
@@ -121,6 +121,4 @@ dependencies {
     androidTestImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
     androidTestImplementation("androidx.room:room-testing:2.6.1")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,17 +13,13 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/ic_app_icon"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SirimOcr"
         android:usesCleartextTraffic="false">
-        android:icon="@drawable/ic_app_icon"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.SirimOcr">
         <activity
             android:name="com.sirimocr.app.ui.activities.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/sirimocr/app/ocr/MLKitOcrProcessor.kt
+++ b/app/src/main/java/com/sirimocr/app/ocr/MLKitOcrProcessor.kt
@@ -7,12 +7,13 @@ import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.sirimocr.app.data.model.SirimData
 import com.sirimocr.app.data.model.SirimOcrResult
+import java.io.Closeable
 import kotlinx.coroutines.tasks.await
 
 class MLKitOcrProcessor(
     private val validationEngine: ValidationEngine = ValidationEngine(),
     private val fieldExtractor: SirimFieldExtractor = SirimFieldExtractor()
-) {
+) : Closeable {
 
     private val textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
@@ -59,5 +60,8 @@ class MLKitOcrProcessor(
         }
         val recognitionScore = if (count == 0) 0f else total / count
         return (recognitionScore * 0.7f + validationScore * 0.3f).coerceIn(0f, 1f)
+    }
+    override fun close() {
+        textRecognizer.close()
     }
 }


### PR DESCRIPTION
## Summary
- clean up the AndroidManifest so the `<application>` element no longer repeats attributes and still registers the FileProvider
- switch the Gradle plugin declaration to `org.jetbrains.kotlin.kapt` and drop duplicated androidTest dependencies for a cleaner build script

## Testing
- `gradle lint` *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d39cc3774883259ef0d3836f45db83